### PR TITLE
Add extension lang files to extension functional test case

### DIFF
--- a/tests/framework/extension_functional_test_case.php
+++ b/tests/framework/extension_functional_test_case.php
@@ -209,6 +209,8 @@ abstract class extension_functional_test_case extends phpbb_functional_test_case
 			{
 				$this->add_lang_ext($file);
 			}
+
+			return;
 		}
 
 		$lang_path = __DIR__ . "/../../language/en/$lang_file.php";


### PR DESCRIPTION
This should allow extensions to load their own lang files in functional testing, and use this->lang() instead of hardcoding language into their tests, e.g.:

```
$this->add_lang_ext(array('boardrules_common', 'boardrules_controller');

$this->assertContains($this->lang('BOARDRULES_HEADER'), $crawler->text());
$this->assertContains($this->lang('BOARDRULES'), $crawler->text());
```

This is based off the add_lang() function from the phpbb_functional_test_case
