### PR TITLE
Fixes to work with DEBUG_CONTAINER

### DIFF
--- a/tests/framework/extension_database_test_case.php
+++ b/tests/framework/extension_database_test_case.php
@@ -181,6 +181,7 @@ abstract class extension_database_test_case extends phpbb_database_test_case
 
 @define('PHPBB_INSTALLED', true);
 @define('DEBUG', true);
+@define('DEBUG_CONTAINER', true);
 
 ";
 		if (file_put_contents($phpbb_root_path . 'config.' . $phpEx, $contents) === false)


### PR DESCRIPTION
Because of these commits:
https://github.com/phpbb/phpbb/commit/22090dc3a3280d043ff5e77212ee7229b5eb0d24
https://github.com/phpbb/phpbb/commit/03667081e1d0a33e7867e9e261044369c45dd8ad

Not sure if it should be set to TRUE or FALSE though
