### PR TITLE
Proposed variables for PHP, NPM and Composer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,24 +6,28 @@ on:
       EXTNAME:
         required: true
         type: string
-      SNIFF:
+      PHPBB_BRANCH:
         required: true
+        type: string
+      SNIFF:
+        required: false
+        default: '1'
         type: string
       IMAGE_ICC:
-        required: true
+        required: false
+        default: '1'
         type: string
       EPV:
-        required: true
+        required: false
+        default: '1'
         type: string
       EXECUTABLE_FILES:
-        required: true
+        required: false
+        default: '1'
         type: string
       CODECOV:
         required: false
         default: '0'
-        type: string
-      PHPBB_BRANCH:
-        required: true
         type: string
       RUN_BASIC_JOBS:
         required: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,7 +138,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
           matrix:
-            php: ${{ fromJson(inputs.ALL_PHP_VERSIONS) }}
+            php: ${{ fromJSON(inputs.ALL_PHP_VERSIONS) }}
             db: ['mysql:5.7']
             include:
               - php: ${{ inputs.MIN_PHP_VERSION }}
@@ -261,7 +261,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
           matrix:
-            php: ${{ fromJson(inputs.ALL_PHP_VERSIONS) }}
+            php: ${{ fromJSON(inputs.ALL_PHP_VERSIONS) }}
             db: ['postgres:14']
             include:
               - php: ${{ inputs.MIN_PHP_VERSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ on:
         required: false
         type: string
         default: '1'
-      RUN_POSTGRESQL_JOBS:
+      RUN_PGSQL_JOBS:
         required: false
         type: string
         default: '1'
@@ -289,7 +289,7 @@ jobs:
 
     # START PostgreSQL Job
     postgres-tests:
-        if: ${{ inputs.RUN_POSTGRESQL_JOBS == '1' }}
+        if: ${{ inputs.RUN_PGSQL_JOBS == '1' }}
         runs-on: ubuntu-22.04
         strategy:
           matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
                 db: 'mysql:5.6'
                 db_alias: 'MyISAM Tests'
                 MYISAM: 1
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ startsWith(inputs.MIN_PHP_VERSION, '7') && '7.4' || inputs.MIN_PHP_VERSION }}
                 db: 'mysql:8.0'
                 COVERAGE: ${{ inputs.CODECOV == '1' && '1' || '0' }}
                 db_alias: ${{ inputs.CODECOV == '1' && 'mysql:8.0 with Coverage' || 'mysql:8.0' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,15 @@ jobs:
             db: ['mysql:5.7']
             include:
               - php: ${{ inputs.MIN_PHP_VERSION }}
-                db: ['mariadb:10.1', 'mariadb:10.2', 'mariadb:10.3', 'mariadb:10.4', 'mariadb:10.5']
+                db: 'mariadb:10.1'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'mariadb:10.2'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'mariadb:10.3'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'mariadb:10.4'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'mariadb:10.5'
               - php: ${{ inputs.MIN_PHP_VERSION }}
                 db: 'mysql:5.6'
               - php: ${{ inputs.MIN_PHP_VERSION }}
@@ -265,7 +273,17 @@ jobs:
             db: ['postgres:14']
             include:
               - php: ${{ inputs.MIN_PHP_VERSION }}
-                db: ['postgres:9.5', 'postgres:9.6', 'postgres:10', 'postgres:11', 'postgres:12', 'postgres:13']
+                db: 'postgres:9.5'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'postgres:9.6'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'postgres:10'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'postgres:11'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'postgres:12'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'postgres:13'
 
         name: PHP ${{ matrix.php }} - ${{ matrix.db }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,7 +247,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 20
-            
+
             - name: Run npm ci
               if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
               run: npm ci
@@ -388,7 +388,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 20
-            
+
             - name: Run npm ci
               if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
               run: npm ci
@@ -505,7 +505,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 20
-            
+
             - name: Run npm ci
               if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
               run: npm ci
@@ -636,7 +636,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 20
-            
+
             - name: Run npm ci
               if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
               run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -541,8 +541,11 @@ jobs:
                   - ${{ startsWith(inputs.PRIMARY_PHP_VERSION, '7') && '7.4' || inputs.PRIMARY_PHP_VERSION }}
                 db:
                   - postgres
+                type:
+                  - unit
+                  - functional
 
-        name: PHP ${{ matrix.php }} - Windows
+        name: PHP ${{ matrix.php }} - Windows - ${{ matrix.type }}
 
         steps:
             - name: Prepare git for Windows
@@ -656,7 +659,13 @@ jobs:
                 Copy-Item ".github\phpunit*" -Destination "phpBB\ext\$env:EXTNAME\.github" -Force
               working-directory: .\phpBB3
 
-            - name: Run tests
-              run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$env:EXTNAME/.github/phpunit-psql-windows-github.xml --bootstrap ./tests/bootstrap.php --verbose --stop-on-error
+            - name: Run unit tests
+              if: ${{ matrix.type == 'unit' }}
+              run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$env:EXTNAME/.github/phpunit-psql-windows-github.xml --bootstrap ./tests/bootstrap.php --verbose --stop-on-error --exclude-group functional
+              working-directory: .\phpBB3
+
+            - name: Run functional tests
+              if: ${{ matrix.type == 'functional' }}
+              run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$env:EXTNAME/.github/phpunit-psql-windows-github.xml --bootstrap ./tests/bootstrap.php --verbose --stop-on-error --group functional
               working-directory: .\phpBB3
     # END IIS & PostgreSQL on Windows Tests Job

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,14 @@ on:
         required: false
         type: string
         default: '1'
+      RUN_NPM_INSTALL:
+        required: false
+        type: string
+        default: '0'
+      RUN_COMPOSER_INSTALL:
+        required: false
+        type: string
+        default: '0'
       MIN_PHP_VERSION:
         required: false
         type: string
@@ -230,6 +238,22 @@ jobs:
               run: .github/setup-database.sh $DB $MYISAM
               working-directory: ./phpBB3
 
+            - name: Install NPM dependencies
+              if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+            
+            - name: Run npm ci
+              if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
+              run: npm ci
+              working-directory: ./phpBB3/phpBB/ext/${{ env.EXTNAME }}
+
+            - name: Install composer dependencies
+              if: ${{ inputs.RUN_COMPOSER_INSTALL == '1' }}
+              run: composer install
+              working-directory: ./phpBB3/phpBB/ext/${{ env.EXTNAME }}
+
             - name: Setup PHPUnit files
               env:
                   DB: ${{steps.database-type.outputs.db}}
@@ -355,6 +379,22 @@ jobs:
               run: .github/setup-database.sh $DB $MYISAM
               working-directory: ./phpBB3
 
+            - name: Install NPM dependencies
+              if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+            
+            - name: Run npm ci
+              if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
+              run: npm ci
+              working-directory: ./phpBB3/phpBB/ext/${{ env.EXTNAME }}
+
+            - name: Install composer dependencies
+              if: ${{ inputs.RUN_COMPOSER_INSTALL == '1' }}
+              run: composer install
+              working-directory: ./phpBB3/phpBB/ext/${{ env.EXTNAME }}
+
             - name: Setup PHPUnit files
               run: mkdir -p phpBB/ext/$EXTNAME/.github && cp .github/phpunit* $_
               working-directory: ./phpBB3
@@ -455,6 +495,22 @@ jobs:
                   MYISAM: '0'
               run: .github/setup-database.sh $DB $MYISAM
               working-directory: ./phpBB3
+
+            - name: Install NPM dependencies
+              if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+            
+            - name: Run npm ci
+              if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
+              run: npm ci
+              working-directory: ./phpBB3/phpBB/ext/${{ env.EXTNAME }}
+
+            - name: Install composer dependencies
+              if: ${{ inputs.RUN_COMPOSER_INSTALL == '1' }}
+              run: composer install
+              working-directory: ./phpBB3/phpBB/ext/${{ env.EXTNAME }}
 
             - name: Setup PHPUnit files
               run: mkdir -p phpBB/ext/$EXTNAME/.github && cp .github/phpunit* $_

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,15 @@ on:
       RUN_MSSQL_JOBS:
         required: false
         type: string
-        default: '1'    
+        default: '1'
+      MIN_PHP_VERSION:
+        required: false
+        type: string
+        default: '7.2'
+      ALL_PHP_VERSIONS:
+        required: false
+        type: string
+        default: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -62,8 +70,8 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - php: '7.2'
-                      db: "none"
+                    - php: ${{ inputs.MIN_PHP_VERSION }}
+                      db: 'none'
                       NOTESTS: 1
 
         name: PHP ${{ matrix.php }} - ${{ matrix.db }}
@@ -129,44 +137,22 @@ jobs:
         if: ${{ inputs.RUN_MYSQL_JOBS == '1' }}
         runs-on: ubuntu-22.04
         strategy:
-            matrix:
-                include:
-                    - php: '7.2'
-                      db: "mariadb:10.1"
-                    - php: '7.2'
-                      db: "mariadb:10.2"
-                    - php: '7.2'
-                      db: "mariadb:10.3"
-                    - php: '7.2'
-                      db: "mariadb:10.4"
-                    - php: '7.2'
-                      db: "mariadb:10.5"
-                    - php: '7.2'
-                      db: "mysql:5.6"
-                      db_alias: "MyISAM Tests"
-                      MYISAM: 1
-                    - php: '7.2'
-                      db: "mysql:5.6"
-                    - php: '7.2'
-                      db: "mysql:5.7"
-                      COVERAGE: ${{ inputs.CODECOV == '1' && '1' || '0' }}
-                      db_alias: ${{ inputs.CODECOV == '1' && 'mysql:5.7 with Coverage' || 'mysql:5.7' }}
-                    - php: '7.3'
-                      db: "mysql:5.7"
-                    - php: '7.4'
-                      db: "mysql:5.7"
-                    - php: '7.4'
-                      db: "mysql:8.0"
-                    - php: '8.0'
-                      db: "mysql:5.7"
-                    - php: '8.1'
-                      db: "mysql:5.7"
-                    - php: '8.2'
-                      db: "mysql:5.7"
-                    - php: '8.3'
-                      db: "mysql:5.7"
-                    - php: '8.4'
-                      db: "mysql:5.7"
+          matrix:
+            php: ${{ fromJson(inputs.ALL_PHP_VERSIONS) }}
+            db: ['mysql:5.7']
+            include:
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: ['mariadb:10.1', 'mariadb:10.2', 'mariadb:10.3', 'mariadb:10.4', 'mariadb:10.5']
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'mysql:5.6'
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'mysql:5.6'
+                db_alias: 'MyISAM Tests'
+                MYISAM: 1
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: 'mysql:8.0'
+                COVERAGE: ${{ inputs.CODECOV == '1' && '1' || '0' }}
+                db_alias: ${{ inputs.CODECOV == '1' && 'mysql:8.0 with Coverage' || 'mysql:8.0' }}
 
         name: PHP ${{ matrix.php }} - ${{ matrix.db_alias != '' && matrix.db_alias || matrix.db }}
 
@@ -274,36 +260,12 @@ jobs:
         if: ${{ inputs.RUN_POSTGRESQL_JOBS == '1' }}
         runs-on: ubuntu-22.04
         strategy:
-            matrix:
-                include:
-                    - php: '7.2'
-                      db: "postgres:9.5"
-                    - php: '7.2'
-                      db: "postgres:9.6"
-                    - php: '7.2'
-                      db: "postgres:10"
-                    - php: '7.2'
-                      db: "postgres:11"
-                    - php: '7.2'
-                      db: "postgres:12"
-                    - php: '7.2'
-                      db: "postgres:13"
-                    - php: '7.3'
-                      db: "postgres:13"
-                    - php: '7.4'
-                      db: "postgres:13"
-                    - php: '8.0'
-                      db: "postgres:12"
-                    - php: '8.0'
-                      db: "postgres:13"
-                    - php: '8.1'
-                      db: "postgres:14"
-                    - php: '8.2'
-                      db: "postgres:14"
-                    - php: '8.3'
-                      db: "postgres:14"
-                    - php: '8.4'
-                      db: "postgres:14"
+          matrix:
+            php: ${{ fromJson(inputs.ALL_PHP_VERSIONS) }}
+            db: ['postgres:14']
+            include:
+              - php: ${{ inputs.MIN_PHP_VERSION }}
+                db: ['postgres:9.5', 'postgres:9.6', 'postgres:10', 'postgres:11', 'postgres:12', 'postgres:13']
 
         name: PHP ${{ matrix.php }} - ${{ matrix.db }}
 
@@ -393,12 +355,12 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - php: '7.2'
+                    - php: ${{ inputs.MIN_PHP_VERSION }}
                       db: "sqlite3"
-                    - php: '7.2'
+                    - php: ${{ inputs.MIN_PHP_VERSION }}
                       db: "mcr.microsoft.com/mssql/server:2019-CU27-ubuntu-20.04"
                       db_alias: 'MSSQL 2019'
-                    - php: '7.2'
+                    - php: ${{ inputs.MIN_PHP_VERSION }}
                       db: "mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04"
                       db_alias: 'MSSQL 2022'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -541,11 +541,8 @@ jobs:
                   - ${{ startsWith(inputs.PRIMARY_PHP_VERSION, '7') && '7.4' || inputs.PRIMARY_PHP_VERSION }}
                 db:
                   - postgres
-                type:
-                  - unit
-                  - functional
 
-        name: PHP ${{ matrix.php }} - Windows - ${{ matrix.type }}
+        name: PHP ${{ matrix.php }} - Windows
 
         steps:
             - name: Prepare git for Windows
@@ -659,13 +656,7 @@ jobs:
                 Copy-Item ".github\phpunit*" -Destination "phpBB\ext\$env:EXTNAME\.github" -Force
               working-directory: .\phpBB3
 
-            - name: Run unit tests
-              if: ${{ matrix.type == 'unit' }}
-              run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$env:EXTNAME/.github/phpunit-psql-windows-github.xml --bootstrap ./tests/bootstrap.php --verbose --stop-on-error --exclude-group functional
-              working-directory: .\phpBB3
-
-            - name: Run functional tests
-              if: ${{ matrix.type == 'functional' }}
-              run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$env:EXTNAME/.github/phpunit-psql-windows-github.xml --bootstrap ./tests/bootstrap.php --verbose --stop-on-error --group functional
+            - name: Run tests
+              run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$env:EXTNAME/.github/phpunit-psql-windows-github.xml --bootstrap ./tests/bootstrap.php --verbose --stop-on-error
               working-directory: .\phpBB3
     # END IIS & PostgreSQL on Windows Tests Job

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,10 @@ on:
         required: false
         type: string
         default: '1'
+      RUN_WINDOWS_JOBS:
+        required: false
+        type: string
+        default: '1'
       RUN_NPM_INSTALL:
         required: false
         type: string
@@ -526,3 +530,142 @@ jobs:
               run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$EXTNAME/.github/phpunit-$DB-github.xml --bootstrap ./tests/bootstrap.php
               working-directory: ./phpBB3
     # END Other Tests Job
+
+    # Test with IIS & PostgreSQL on Windows
+    windows-tests:
+        if: ${{ inputs.RUN_WINDOWS_JOBS == '1' }}
+        runs-on: windows-latest
+        strategy:
+            matrix:
+                php:
+                  - ${{ startsWith(inputs.PRIMARY_PHP_VERSION, '7') && '7.4' || inputs.PRIMARY_PHP_VERSION }}
+                db:
+                  - postgres
+                type:
+                  - unit
+                  - functional
+
+        name: PHP ${{ matrix.php }} - Windows - ${{ matrix.type }}
+
+        steps:
+            - name: Prepare git for Windows
+              run: |
+                  git config --system core.autocrlf false
+                  git config --system core.eol lf
+
+            - name: Checkout phpBB
+              uses: actions/checkout@v4
+              with:
+                  repository: phpbb/phpbb
+                  ref: ${{ env.PHPBB_BRANCH }}
+                  path: phpBB3
+
+            - name: Checkout extension
+              uses: actions/checkout@v4
+              with:
+                  path: phpBB3/phpBB/ext/${{ env.EXTNAME }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, intl, gd, exif, iconv, pgsql, pdo_pgsql
+                  ini-values: upload_tmp_dir=${{ runner.temp }}, sys_temp_dir=${{ runner.temp }}
+                  coverage: none
+
+            - name: Setup environment for phpBB
+              env:
+                  GITHUB_WORKSPACE: ${{ github.workspace }}
+                  TEMP_DIR: ${{ runner.temp }}
+              run: |
+                  Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServerRole, IIS-WebServer, IIS-CommonHttpFeatures, IIS-ManagementConsole, IIS-HttpErrors, IIS-HttpRedirect, IIS-WindowsAuthentication, IIS-StaticContent, IIS-DefaultDocument, IIS-HttpCompressionStatic, IIS-DirectoryBrowsing, IIS-WebServerManagementTools, IIS-CGI -All
+                  Set-Service wuauserv -StartupType Manual
+                  (Get-Content ${env:GITHUB_WORKSPACE}\phpBB3\phpBB\web.config).replace("<configuration>", "<configuration>`n`t<system.web>`n`t`t<customErrors mode=`"Off`"/>`n`t</system.web>") | Set-Content ${env:GITHUB_WORKSPACE}\phpBB3\phpBB\web.config
+                  (Get-Content ${env:GITHUB_WORKSPACE}\phpBB3\phpBB\web.config).replace("`t</system.webServer>", "`t`t<httpErrors errorMode=`"Detailed`" />`n`t</system.webServer>") | Set-Content ${env:GITHUB_WORKSPACE}\phpBB3\phpBB\web.config
+                  choco install urlrewrite -y
+                  Import-Module WebAdministration
+                  New-WebSite -Name 'phpBBTest' -PhysicalPath "${env:GITHUB_WORKSPACE}\phpBB3\phpBB" -Force
+                  $session = Get-PSSession -Name WinPSCompatSession
+                  $sb = {Set-ItemProperty 'IIS:\Sites\phpBBTest' -name Bindings -value @{protocol='http';bindingInformation='*:80:phpbb.test'}}
+                  Invoke-Command -Scriptblock $sb -Session $session
+                  $sb = {Set-WebConfigurationProperty -filter /system.WebServer/security/authentication/AnonymousAuthentication -name enabled -value true -location "IIS:\Sites\phpBBTest"}
+                  Invoke-Command -Scriptblock $sb -Session $session
+                  Add-Content -Path $env:windir\System32\drivers\etc\hosts -Value "`r`n127.0.0.1`tphpbb.test" -Force
+                  [System.Environment]::SetEnvironmentVariable('PATH',$Env:PATH+";%windir%\system32\inetsrv")
+                  echo Setup FAST-CGI configuration
+                  Add-WebConfiguration -Filter /system.webServer/fastCgi -PSPath IIS:\ -Value @{fullpath="C:\tools\php\php-cgi.exe"}
+                  echo Setup FACT-CGI handler
+                  New-WebHandler -Name "PHP-FastCGI" -Path "*.php" -Modules FastCgiModule -ScriptProcessor "C:\tools\php\php-cgi.exe" -Verb '*' -ResourceType Either
+                  iisreset
+                  NET START W3SVC
+                  mkdir "${env:GITHUB_WORKSPACE}\phpBB3\phpBB\cache\test"
+                  mkdir "${env:GITHUB_WORKSPACE}\phpBB3\phpBB\cache\installer"
+                  icacls "${env:GITHUB_WORKSPACE}\phpBB3\phpBB\cache" /grant Users:F /T
+                  icacls "${env:GITHUB_WORKSPACE}\phpBB3\phpBB\files" /grant Users:F /T
+                  icacls "${env:GITHUB_WORKSPACE}\phpBB3\phpBB\store" /grant Users:F /T
+                  icacls "${env:GITHUB_WORKSPACE}\phpBB3\phpBB\images\avatars\upload" /grant Users:F /T
+                  $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule("IIS_IUSRS", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow")
+                  $acl = Get-ACL "${env:TEMP_DIR}"
+                  $acl.AddAccessRule($accessRule)
+                  Set-ACL -Path "${env:TEMP_DIR}" -ACLObject $acl
+                  cd ${env:GITHUB_WORKSPACE}\phpBB3\phpBB
+                  php ..\composer.phar install
+                  php ..\composer.phar remove phpunit/dbunit --dev --update-with-dependencies
+                  php ..\composer.phar require symfony/yaml:~4.4 misantron/dbunit:~5.0 phpunit/phpunit:^9.3 doctrine/instantiator:^1.4 --dev --update-with-all-dependencies --ignore-platform-reqs
+                  cd ..
+
+            - name: Setup database
+              run: |
+                  $postgreSqlSvc = Get-Service "postgresql*"
+                  Set-Service $postgreSqlSvc.Name -StartupType manual
+                  $runningStatus = [System.ServiceProcess.ServiceControllerStatus]::Running
+                  $maxStartTimeout = New-TimeSpan -Seconds 30
+                  try {
+                    $postgreSqlSvc.Start()
+                    $postgreSqlSvc.WaitForStatus($runningStatus, $maxStartTimeout)
+                  } catch  {
+                    $_ | select *
+                  }
+                  [System.Environment]::SetEnvironmentVariable('PATH',$Env:PATH+";${env:PGBIN}")
+                  $env:PGPASSWORD = 'root'
+                  psql -c 'ALTER SYSTEM SET hot_standby = on;' -U postgres
+                  psql -c 'ALTER SYSTEM SET wal_level = minimal;' -U postgres
+                  psql -c 'DROP DATABASE IF EXISTS phpbb_tests;' -U postgres
+                  psql -c 'create database phpbb_tests;' -U postgres
+                  Set-MpPreference -ExclusionPath "${env:PGDATA}" # Exclude PGDATA directory from Windows Defender
+                  Set-MpPreference -DisableRealtimeMonitoring $true
+
+            - name: Install NPM dependencies
+              if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+            
+            - name: Run npm ci
+              if: ${{ inputs.RUN_NPM_INSTALL == '1' }}
+              run: npm ci
+              working-directory: .\phpBB3\phpBB\ext\${{ env.EXTNAME }}
+
+            - name: Install composer dependencies
+              if: ${{ inputs.RUN_COMPOSER_INSTALL == '1' }}
+              run: composer install
+              working-directory: .\phpBB3\phpBB\ext\${{ env.EXTNAME }}
+
+            - name: Setup PHPUnit files
+              run: |
+                if (-not (Test-Path "phpBB\ext\$env:EXTNAME\.github")) { 
+                  mkdir "phpBB\ext\$env:EXTNAME\.github" 
+                }
+                Copy-Item ".github\phpunit*" -Destination "phpBB\ext\$env:EXTNAME\.github" -Force
+              working-directory: .\phpBB3
+
+            - name: Run unit tests
+              if: ${{ matrix.type == 'unit' }}
+              run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$env:EXTNAME/.github/phpunit-psql-windows-github.xml --bootstrap ./tests/bootstrap.php --verbose --stop-on-error --exclude-group functional
+              working-directory: .\phpBB3
+
+            - name: Run functional tests
+              if: ${{ matrix.type == 'functional' }}
+              run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$env:EXTNAME/.github/phpunit-psql-windows-github.xml --bootstrap ./tests/bootstrap.php --verbose --stop-on-error --group functional
+              working-directory: .\phpBB3
+    # END IIS & PostgreSQL on Windows Tests Job

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,11 +49,11 @@ on:
         required: false
         type: string
         default: '0'
-      MIN_PHP_VERSION:
+      PRIMARY_PHP_VERSION:
         required: false
         type: string
         default: '7.2'
-      ALL_PHP_VERSIONS:
+      PHP_VERSION_MATRIX:
         required: false
         type: string
         default: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
@@ -78,7 +78,7 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - php: ${{ inputs.MIN_PHP_VERSION }}
+                    - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                       db: 'none'
                       NOTESTS: 1
 
@@ -146,26 +146,26 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
           matrix:
-            php: ${{ fromJSON(inputs.ALL_PHP_VERSIONS) }}
+            php: ${{ fromJSON(inputs.PHP_VERSION_MATRIX) }}
             db: ['mysql:5.7']
             include:
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'mariadb:10.1'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'mariadb:10.2'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'mariadb:10.3'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'mariadb:10.4'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'mariadb:10.5'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'mysql:5.6'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'mysql:5.6'
                 db_alias: 'MyISAM Tests'
                 MYISAM: 1
-              - php: ${{ startsWith(inputs.MIN_PHP_VERSION, '7') && '7.4' || inputs.MIN_PHP_VERSION }}
+              - php: ${{ startsWith(inputs.PRIMARY_PHP_VERSION, '7') && '7.4' || inputs.PRIMARY_PHP_VERSION }}
                 db: 'mysql:8.0'
                 COVERAGE: ${{ inputs.CODECOV == '1' && '1' || '0' }}
                 db_alias: ${{ inputs.CODECOV == '1' && 'mysql:8.0 with Coverage' || 'mysql:8.0' }}
@@ -293,20 +293,20 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
           matrix:
-            php: ${{ fromJSON(inputs.ALL_PHP_VERSIONS) }}
+            php: ${{ fromJSON(inputs.PHP_VERSION_MATRIX) }}
             db: ['postgres:14']
             include:
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'postgres:9.5'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'postgres:9.6'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'postgres:10'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'postgres:11'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'postgres:12'
-              - php: ${{ inputs.MIN_PHP_VERSION }}
+              - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                 db: 'postgres:13'
 
         name: PHP ${{ matrix.php }} - ${{ matrix.db }}
@@ -413,12 +413,12 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - php: ${{ inputs.MIN_PHP_VERSION }}
+                    - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                       db: "sqlite3"
-                    - php: ${{ inputs.MIN_PHP_VERSION }}
+                    - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                       db: "mcr.microsoft.com/mssql/server:2019-CU27-ubuntu-20.04"
                       db_alias: 'MSSQL 2019'
-                    - php: ${{ inputs.MIN_PHP_VERSION }}
+                    - php: ${{ inputs.PRIMARY_PHP_VERSION }}
                       db: "mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04"
                       db_alias: 'MSSQL 2022'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,6 @@ on:
         required: false
         default: '0'
         type: string
-      RUN_BASIC_JOBS:
-        required: false
-        type: string
-        default: '1'
       RUN_MYSQL_JOBS:
         required: false
         type: string
@@ -81,7 +77,7 @@ env:
 jobs:
     # START Basic Checks Job (EPV, code sniffer, images check, etc.)
     basic-checks:
-        if: ${{ inputs.RUN_BASIC_JOBS == '1' }}
+        if: ${{ inputs.EPV == '1' || inputs.EXECUTABLE_FILES == '1' || inputs.IMAGE_ICC == '1' || inputs.SNIFF == '1' }}
         runs-on: ubuntu-22.04
         strategy:
             matrix:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ call-tests:
         # Default: 1
         RUN_MSSQL_JOBS: 1
 
+        # Set this to 0 to skip all Windows IIS & PostgreSQL tests.
+        # Default: 1
+        RUN_WINDOWS_JOBS: 1
+
         # Set this to 1 if your extension relies on NPM dependencies.
         # Default: 0
         RUN_NPM_INSTALL: 0

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Use the branch that matches the phpBB version you're developing for.
 
 ## ✅ Requirements
 
-- Your extension's package contents must be located at the root level of the repository. That is, the repository **must directly represent the package**, with all relevant files such as `composer.json`, `README`, `LICENSE`, etc. placed directly in the **root of the repository**, **not inside a subdirectory within the repository**. See any of phpbb-extension's official extension repositories as an example.
+- Your extension's package contents must be located at the root level of the repository. That is, the repository **must directly represent the package**, with all relevant files such as `composer.json`, `README`, `LICENSE`, etc. placed directly in the **root of the repository**, **not inside a subdirectory within the repository**.
 - Tests must be defined in your repository using PHPUnit.
 
 ## 🛠 Advanced Configuration Options

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ name: Tests
 
 on:
     push:
-        branches:        # Run tests when commits are pushed to these branches in your repo
+        branches:   # Run tests when commits are pushed to these branches in your repo
             - main
             - master
             - develop
             - dev/*
-    pull_request:        # Run tests when pull requests are made on these branches in your repo
+    pull_request:   # Run tests when pull requests are made on these branches in your repo
         branches:
             - main
             - master
@@ -50,14 +50,9 @@ jobs:
         uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x  # Must match PHPBB_BRANCH
         with:
             EXTNAME: acme/demo   # Your extension vendor/package name
-            SNIFF: 1             # Run code sniffer on your code? 1 or 0
-            IMAGE_ICC: 1         # Run icc profile sniffer on your images? 1 or 0
-            EPV: 1               # Run EPV (Extension Pre Validator) on your code? 1 or 0
-            EXECUTABLE_FILES: 1  # Run check for executable files? 1 or 0
-            CODECOV: 0           # Run code coverage via codecov? 1 or 0
             PHPBB_BRANCH: 3.3.x  # The phpBB branch to run tests on
         secrets:
-            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # Do not edit this
+            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # Do not edit or remove this
 ```
 
 ### Branches
@@ -82,15 +77,33 @@ call-tests:
     uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x
     with:
         EXTNAME: acme/demo   # Your extension vendor/package name
-        SNIFF: 1             # Run code sniffer on your code? 1 or 0
-        IMAGE_ICC: 1         # Run icc profile sniffer on your images? 1 or 0
-        EPV: 1               # Run EPV (Extension Pre Validator) on your code? 1 or 0
-        EXECUTABLE_FILES: 1  # Run check for executable files? 1 or 0
-        CODECOV: 0           # Run code coverage via codecov? 1 or 0
         PHPBB_BRANCH: 3.3.x  # The phpBB branch to run tests on
 
-        # OPTIONAL ADVANCED CONFIGURATIONS BELOW
-        # The following arguments are all optional and can be omitted if not needed.
+        # OPTIONAL CONFIGURATIONS BELOW
+        # The following arguments are optional and can be omitted if not needed.
+
+        # Run code sniffer on your code? 1 or 0
+        # Default: 1
+        SNIFF: 1
+
+        # Run icc profile sniffer on your images? 1 or 0
+        # Default: 1
+        IMAGE_ICC: 1
+
+        # Run EPV (Extension Pre Validator) on your code? 1 or 0
+        # Default: 1
+        EPV: 1
+
+        # Run check for executable files? 1 or 0
+        # Default: 1
+        EXECUTABLE_FILES: 1
+
+        # ADVANCED CONFIGURATIONS BELOW
+        # The following arguments are for users that need to tweak the workflow.
+
+        # Set this to 1 to generate a code coverage report. (See documentation below.)
+        # Default: 0
+        CODECOV: 0
 
         # Set this to 0 to skip all basic checks (code sniffer, EPV, etc.)
         # Default: 1

--- a/README.md
+++ b/README.md
@@ -101,10 +101,6 @@ call-tests:
         # ADVANCED CONFIGURATIONS BELOW
         # The following arguments are for users that need to tweak the workflow.
 
-        # Set this to 1 to generate a code coverage report. (See documentation below.)
-        # Default: 0
-        CODECOV: 0
-
         # Set this to 0 to skip all MySQL/MariaDB tests.
         # Default: 1
         RUN_MYSQL_JOBS: 1
@@ -140,6 +136,10 @@ call-tests:
         # List the PHP versions you want your extension tested with.
         # Default: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
         PHP_VERSION_MATRIX: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
+
+        # Set this to 1 to generate a code coverage report. (See documentation below.)
+        # Default: 0
+        CODECOV: 0
 ```
 
 ## 📊 Code Coverage with Codecov

--- a/README.md
+++ b/README.md
@@ -73,51 +73,59 @@ Use the branch that matches the phpBB version you're developing for.
 
 ## 🛠 Advanced Configuration Options
 
-You can fine-tune this workflow with several optional arguments:
-
-## 🔃 Selectively Run Job Groups
-
-By default, all test job groups run. You can skip any by setting their arguments to 0:
+You can fine-tune this workflow with several optional arguments in the `with` section:
 
 ```yaml
-with:
-    ...
-    RUN_BASIC_JOBS: 0       # Skip checks like sniffer, EPV, etc.
-    RUN_MYSQL_JOBS: 0       # Skip MySQL/MariaDB tests
-    RUN_POSTGRESQL_JOBS: 0  # Skip PostgreSQL tests
-    RUN_MSSQL_JOBS: 0       # Skip MSSQL and SQLite3 tests
+call-tests:
+    uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x
+    with:
+        EXTNAME: acme/demo   # Your extension vendor/package name
+        SNIFF: 1             # Run code sniffer on your code? 1 or 0
+        IMAGE_ICC: 1         # Run icc profile sniffer on your images? 1 or 0
+        EPV: 1               # Run EPV (Extension Pre Validator) on your code? 1 or 0
+        EXECUTABLE_FILES: 1  # Run check for executable files? 1 or 0
+        CODECOV: 0           # Run code coverage via codecov? 1 or 0
+        PHPBB_BRANCH: 3.3.x  # The phpBB branch to run tests on
+
+        # OPTIONAL ADVANCED CONFIGURATIONS BELOW
+        # The following arguments are all optional and can be omitted if not needed.
+
+        # Set this to 0 to skip all basic checks (code sniffer, EPV, etc.)
+        # Default: 1
+        RUN_BASIC_JOBS: 1
+
+        # Set this to 0 to skip all MySQL/MariaDB tests.
+        # Default: 1
+        RUN_MYSQL_JOBS: 1
+
+        # Set this to 0 to skip all PostgreSQL tests.
+        # Default: 1
+        RUN_PGSQL_JOBS: 1
+
+        # Set this to 0 to skip all MSSQL and SQLite3 tests.
+        # Default: 1
+        RUN_MSSQL_JOBS: 1
+
+        # Set this to 1 if your extension relies on NPM dependencies.
+        # Default: 0
+        RUN_NPM_INSTALL: 0
+
+        # Set this to 1 if your extension relies on Composer dependencies.
+        # Default: 0
+        RUN_COMPOSER_INSTALL: 0
+
+        # CUSTOMISE PHP VERSIONS
+        # To override the default PHP versions tested (7.2 through 8.4):
+
+        # Preferred PHP version used for all test jobs.
+        # Default: '7.2'
+        PRIMARY_PHP_VERSION: '7.2'
+
+        # The MySQL and PostgreSQL jobs run tests across multiple PHP versions.
+        # List the PHP versions you want your extension tested with.
+        # Default: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
+        PHP_VERSION_MATRIX: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
 ```
-
-> 💡 Omit these inputs or set them to 1 to enable each group (default behavior).
-
-## 📦 Install Dependencies
-
-If your extension relies on NPM or Composer dependencies, enable automated installs:
-
-```yaml
-with:
-    ...
-    RUN_NPM_INSTALL: 1        # Run `npm ci`
-    RUN_COMPOSER_INSTALL: 1   # Run `composer install`
-```
-
-> 💡 Omit if not needed.
-
-## 🐘 Customise PHP Versions
-
-To override the default PHP versions tested (7.2 through 8.4), use:
-
-```yaml
-with:
-    ...
-    PRIMARY_PHP_VERSION: '8.1'
-    PHP_VERSION_MATRIX: '["8.0", "8.1", "8.2", "8.3", "8.4"]'
-```
-
-- `PRIMARY_PHP_VERSION`: PHP version used for all jobs, including checks and MSSQL. Default is 7.2.
-- `PHP_VERSION_MATRIX`: List of all PHP versions you want tested (in MySQL and PostgreSQL jobs).
-
-> 💡 Use this if your extension supports a limited or newer PHP version range. Omit if not needed.
 
 ## 📊 Code Coverage with Codecov
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ Reusable GitHub Actions workflow for testing phpBB extensions across multiple en
 
 This repository contains a pre-configured test workflow designed for phpBB extension developers. It runs your extension's tests using various PHP versions and database systems, including **MySQL**, **PostgreSQL**, **SQLite**, and **Microsoft SQL Server**.
 
-## 🚀 Features
+## Table of Contents
+
+- [✨ Features](#-features)
+- [🚀 How to Use](#-how-to-use)
+- [🧪 Branches](#-branches)
+- [✅ Requirements](#-requirements)
+- [⏭️ Skipping Jobs](#️-skipping-jobs)
+- [📦 Dependency Installation](#-dependency-installation)
+- [⚙️ Customising the PHP Test Suite](#️-customising-the-php-test-suite)
+- [📊 Code Coverage with Codecov](#-code-coverage-with-codecov)
+- [📄 License](#-license)
+
+## ✨ Features
 
 - Supports **PHP 7.2+** through **8.x**
 - Tests against multiple database engines
@@ -15,14 +27,7 @@ This repository contains a pre-configured test workflow designed for phpBB exten
   - Executable files
   - Code coverage via Codecov
 
-## 🧪 Branches
-
-- `3.3.x`: Targets the **phpBB 3.3.x** release line.
-- `master`: Targets the latest development version of **phpBB** (`master` branch).
-
-Use the branch that matches the phpBB version you're developing for.
-
-## 📦 How to Use
+## 🚀 How to Use
 
 On GitHub.com, go to your extension's repository, click **Add file → Create new file**, name it `.github/workflows/tests.yml`, add the workflow content shown below, and commit the file. Make sure to replace `acme/demo` with your actual extension vendor/package name, and optionally you may adjust any of the branch names and other checks.
 
@@ -58,10 +63,21 @@ jobs:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # Do not edit this
 ```
 
+## 🧪 Branches
+
+Use the branch that matches the phpBB version you're developing for.
+
+- `3.3.x`: Targets the **phpBB 3.3.x** release line.
+- `master`: Targets the latest development version of **phpBB** (`master` branch).
+
 ## ✅ Requirements
 
 - Your extension's package contents must be located at the root level of the repository. That is, the repository **must directly represent the package**, with all relevant files such as `composer.json`, `README`, `LICENSE`, etc. placed directly in the **root of the repository**, **not inside a subdirectory within the repository**. See any of phpbb-extension's official extension repositories as an example.
 - Tests must be defined in your repository using PHPUnit.
+
+# Advanced Configuration Options
+
+The following sections provide instruction for advanced users who are not able to use the default workflow out-of-the-box configuration. If your tests are failing with the default workflow, it may be because you need to change the PHP versions or skip certain jobs.
 
 ## ⏭️ Skipping Jobs
 
@@ -71,7 +87,7 @@ This test framework runs four primary job groups:
 3. PostgreSQL - Tests using PostgreSQL database structures.
 4. MSSQL - Tests using MSSQL and SQLite3 database structures.
 
-You can skip any of these job groups—such as if your extension does not support MSSQL—by setting the appropriate arguments when using this workflow:
+You can skip any of these job groups—such as if your extension does not support MSSQL—by setting the appropriate optional arguments when using this workflow:
 
 ```yaml
 with:
@@ -84,6 +100,40 @@ with:
 ```
 
 > Note: If you do not need to skip any jobs, you don’t need to include these arguments at all. For example, omitting `RUN_BASIC_JOBS` is equivalent to setting it to 1. You only need to define these arguments if you want to disable a job by setting its value to 0.
+
+## 📦 Dependency Installation
+
+If your extension requires **NPM** or **Composer** dependencies, you can enable automatic installation by setting the following arguments:
+
+```yaml
+with:
+    ...
+    RUN_NPM_INSTALL: 1       # Set to 1 to run `npm ci`; otherwise set to 0 or omit
+    RUN_COMPOSER_INSTALL: 1  # Set to 1 to run `composer install`; otherwise set to 0 or omit
+    ...
+```
+
+> 💡 If you don't need either, you can omit these arguments entirely.
+
+## ⚙️ Customising the PHP Test Suite
+
+By default, this framework tests your extension against the full range of PHP versions supported by phpBB (7.2 through 8.4). You can override this by specifying the following optional inputs:
+
+```yaml
+with:
+    ...
+    PRIMARY_PHP_VERSION: '8.1'
+    PHP_VERSION_MATRIX: '["8.0", "8.1", "8.2", "8.3", "8.4"]'
+    ...
+```
+
+- `PRIMARY_PHP_VERSION`: The PHP version used for **all** jobs, including code checks and database tests. Defaults to `7.2`.  
+- `PHP_VERSION_MATRIX`: A JSON array of PHP versions to test against during **MySQL** and **PostgreSQL** jobs. Defaults to:
+  ```json
+  ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
+  ```
+
+> 💡 Use these options if your extension supports only a specific set of PHP versions, or if you want to test against a narrower or newer PHP version range.
 
 ## 📊 Code Coverage with Codecov
 
@@ -100,26 +150,7 @@ fixes:
 
 Make sure to replace `acme/demo` with your actual extension vendor/package name.
 
-### 2. Sign in to Codecov
-
-- Visit [https://codecov.io](https://codecov.io)
-- Log in with your **GitHub** account
-
-### 3. Get Your Codecov Token (if required)
-
-Most public repositories do **not** require a token.  
-For private repositories or certain CI setups, you may need a global **Codecov token**:
-
-- Go to your [Codecov account settings](https://app.codecov.io/account/token)
-- Copy the token
-
-Then, in your GitHub repository:
-
-- Navigate to **Settings → Secrets and variables → Actions**
-- Click **"New repository secret"**
-- Name it `CODECOV_TOKEN` and paste your token value
-
-### 4. Enable Codecov in the Workflow
+### 2. Enable Codecov in the Workflow
 
 Ensure `CODECOV: 1` is set in your workflow call:
 
@@ -129,6 +160,22 @@ with:
     CODECOV: 1
     ...
 ```
+
+### 3. Get Your Codecov Token (if required)
+
+Most public repositories do **not** require a token.  
+For private repositories or certain CI setups, you may need a global **Codecov token**:
+
+- Visit [https://codecov.io](https://codecov.io)
+- Log in with your **GitHub** account
+- Go to your [Codecov account settings](https://app.codecov.io/account/token)
+- Copy the token
+
+Then, in your GitHub repository:
+
+- Navigate to **Settings → Secrets and variables → Actions**
+- Click **"New repository secret"**
+- Name it `CODECOV_TOKEN` and paste your token value
 
 Once set up, Codecov will automatically collect and display coverage reports for your extension after each test run.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,11 @@ This repository contains a pre-configured test workflow designed for phpBB exten
 
 ## Table of Contents
 
-- [✨ Features](#-features)
-- [🚀 How to Use](#-how-to-use)
-- [🧪 Branches](#-branches)
-- [✅ Requirements](#-requirements)
-- [⏭️ Skipping Jobs](#️-skipping-jobs)
-- [📦 Dependency Installation](#-dependency-installation)
-- [⚙️ Customising the PHP Test Suite](#️-customising-the-php-test-suite)
-- [📊 Code Coverage with Codecov](#-code-coverage-with-codecov)
-- [📄 License](#-license)
+- ✨ [Features](#-features)
+- 🚀 [How to Use](#-how-to-use)
+- ✅ [Requirements](#-requirements)
+- 🛠 [Advanced Configuration Options](#-advanced-configuration-options)
+- 📊 [Code Coverage with Codecov](#-code-coverage-with-codecov)
 
 ## ✨ Features
 
@@ -63,7 +59,7 @@ jobs:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # Do not edit this
 ```
 
-## 🧪 Branches
+### Branches
 
 Use the branch that matches the phpBB version you're developing for.
 
@@ -75,65 +71,53 @@ Use the branch that matches the phpBB version you're developing for.
 - Your extension's package contents must be located at the root level of the repository. That is, the repository **must directly represent the package**, with all relevant files such as `composer.json`, `README`, `LICENSE`, etc. placed directly in the **root of the repository**, **not inside a subdirectory within the repository**. See any of phpbb-extension's official extension repositories as an example.
 - Tests must be defined in your repository using PHPUnit.
 
-# Advanced Configuration Options
+## 🛠 Advanced Configuration Options
 
-The following sections provide instruction for advanced users who are not able to use the default workflow out-of-the-box configuration. If your tests are failing with the default workflow, it may be because you need to change the PHP versions or skip certain jobs.
+You can fine-tune this workflow with several optional arguments:
 
-## ⏭️ Skipping Jobs
+## 🔃 Selectively Run Job Groups
 
-This test framework runs four primary job groups:
-1. Basic checks - These are the code sniffer, icc profile sniffer, executable file and EPV checks.
-2. MySQL - Tests using MySQL and MariaDB database structures.
-3. PostgreSQL - Tests using PostgreSQL database structures.
-4. MSSQL - Tests using MSSQL and SQLite3 database structures.
-
-You can skip any of these job groups—such as if your extension does not support MSSQL—by setting the appropriate optional arguments when using this workflow:
+By default, all test job groups run. You can skip any by setting their arguments to 0:
 
 ```yaml
 with:
     ...
-    RUN_BASIC_JOBS: 1      # Set to 0 to skip; otherwise set to 1 or omit
-    RUN_MYSQL_JOBS: 1      # Set to 0 to skip; otherwise set to 1 or omit
-    RUN_POSTGRESQL_JOBS: 1 # Set to 0 to skip; otherwise set to 1 or omit
-    RUN_MSSQL_JOBS: 0      # Set to 0 to skip; otherwise set to 1 or omit
-    ...
+    RUN_BASIC_JOBS: 0       # Skip checks like sniffer, EPV, etc.
+    RUN_MYSQL_JOBS: 0       # Skip MySQL/MariaDB tests
+    RUN_POSTGRESQL_JOBS: 0  # Skip PostgreSQL tests
+    RUN_MSSQL_JOBS: 0       # Skip MSSQL and SQLite3 tests
 ```
 
-> Note: If you do not need to skip any jobs, you don’t need to include these arguments at all. For example, omitting `RUN_BASIC_JOBS` is equivalent to setting it to 1. You only need to define these arguments if you want to disable a job by setting its value to 0.
+> 💡 Omit these inputs or set them to 1 to enable each group (default behavior).
 
-## 📦 Dependency Installation
+## 📦 Install Dependencies
 
-If your extension requires **NPM** or **Composer** dependencies, you can enable automatic installation by setting the following arguments:
+If your extension relies on NPM or Composer dependencies, enable automated installs:
 
 ```yaml
 with:
     ...
-    RUN_NPM_INSTALL: 1       # Set to 1 to run `npm ci`; otherwise set to 0 or omit
-    RUN_COMPOSER_INSTALL: 1  # Set to 1 to run `composer install`; otherwise set to 0 or omit
-    ...
+    RUN_NPM_INSTALL: 1        # Run `npm ci`
+    RUN_COMPOSER_INSTALL: 1   # Run `composer install`
 ```
 
-> 💡 If you don't need either, you can omit these arguments entirely.
+> 💡 Omit if not needed.
 
-## ⚙️ Customising the PHP Test Suite
+## 🐘 Customise PHP Versions
 
-By default, this framework tests your extension against the full range of PHP versions supported by phpBB (7.2 through 8.4). You can override this by specifying the following optional inputs:
+To override the default PHP versions tested (7.2 through 8.4), use:
 
 ```yaml
 with:
     ...
     PRIMARY_PHP_VERSION: '8.1'
     PHP_VERSION_MATRIX: '["8.0", "8.1", "8.2", "8.3", "8.4"]'
-    ...
 ```
 
-- `PRIMARY_PHP_VERSION`: The PHP version used for **all** jobs, including code checks and database tests. Defaults to `7.2`.  
-- `PHP_VERSION_MATRIX`: A JSON array of PHP versions to test against during **MySQL** and **PostgreSQL** jobs. Defaults to:
-  ```json
-  ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
-  ```
+- `PRIMARY_PHP_VERSION`: PHP version used for all jobs, including checks and MSSQL. Default is 7.2.
+- `PHP_VERSION_MATRIX`: List of all PHP versions you want tested (in MySQL and PostgreSQL jobs).
 
-> 💡 Use these options if your extension supports only a specific set of PHP versions, or if you want to test against a narrower or newer PHP version range.
+> 💡 Use this if your extension supports a limited or newer PHP version range. Omit if not needed.
 
 ## 📊 Code Coverage with Codecov
 
@@ -158,7 +142,6 @@ Ensure `CODECOV: 1` is set in your workflow call:
 with:
     ...
     CODECOV: 1
-    ...
 ```
 
 ### 3. Get Your Codecov Token (if required)

--- a/README.md
+++ b/README.md
@@ -82,14 +82,6 @@ call-tests:
         # OPTIONAL CONFIGURATIONS BELOW
         # The following arguments are optional and can be omitted if not needed.
 
-        # Run code sniffer on your code? 1 or 0
-        # Default: 1
-        SNIFF: 1
-
-        # Run icc profile sniffer on your images? 1 or 0
-        # Default: 1
-        IMAGE_ICC: 1
-
         # Run EPV (Extension Pre Validator) on your code? 1 or 0
         # Default: 1
         EPV: 1
@@ -98,16 +90,20 @@ call-tests:
         # Default: 1
         EXECUTABLE_FILES: 1
 
+        # Run icc profile sniffer on your images? 1 or 0
+        # Default: 1
+        IMAGE_ICC: 1
+
+        # Run code sniffer on your code? 1 or 0
+        # Default: 1
+        SNIFF: 1
+
         # ADVANCED CONFIGURATIONS BELOW
         # The following arguments are for users that need to tweak the workflow.
 
         # Set this to 1 to generate a code coverage report. (See documentation below.)
         # Default: 0
         CODECOV: 0
-
-        # Set this to 0 to skip all basic checks (code sniffer, EPV, etc.)
-        # Default: 1
-        RUN_BASIC_JOBS: 1
 
         # Set this to 0 to skip all MySQL/MariaDB tests.
         # Default: 1

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ This repository contains a pre-configured test workflow designed for phpBB exten
 
 - ✨ [Features](#-features)
 - 🚀 [How to Use](#-how-to-use)
-- ✅ [Requirements](#-requirements)
-- 🛠 [Advanced Configuration Options](#-advanced-configuration-options)
+- 🛠 [Configuration Options](#-configuration-options)
 - 📊 [Code Coverage with Codecov](#-code-coverage-with-codecov)
 
 ## ✨ Features
@@ -18,10 +17,10 @@ This repository contains a pre-configured test workflow designed for phpBB exten
 - Tests against multiple database engines
 - Optional checks for:
   - PHP CodeSniffer
-  - ICC image profiles
+  - Image ICC profile removal
   - EPV (Extension Pre Validator)
-  - Executable files
-  - Code coverage via Codecov
+  - Files with executable permissions
+  - Code coverage reports via Codecov
 
 ## 🚀 How to Use
 
@@ -59,15 +58,23 @@ jobs:
 
 Use the branch that matches the phpBB version you're developing for.
 
-- `3.3.x`: Targets the **phpBB 3.3.x** release line.
-- `master`: Targets the latest development version of **phpBB** (`master` branch).
+- `3.3.x`: Targets the phpBB 3.3.x release line.
+- `master`: Targets the latest development version of phpBB (`master` branch).
 
-## ✅ Requirements
+> ‼️ Whichever branch you choose here, be sure to use the **same value** for both the `PHPBB_BRANCH` and in the `uses:` line after the `@` symbol. For example, if you're targeting the `3.3.x` branch:
+> 
+> ```yaml
+> uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x
+> with:
+>     PHPBB_BRANCH: 3.3.x
+> ```
+
+### Requirements
 
 - Your extension's package contents must be located at the root level of the repository. That is, the repository **must directly represent the package**, with all relevant files such as `composer.json`, `README`, `LICENSE`, etc. placed directly in the **root of the repository**, **not inside a subdirectory within the repository**.
 - Tests must be defined in your repository using PHPUnit.
 
-## 🛠 Advanced Configuration Options
+## 🛠 Configuration Options
 
 You can fine-tune this workflow with several optional arguments in the `with` section:
 
@@ -82,46 +89,43 @@ call-tests:
         # OPTIONAL CONFIGURATIONS BELOW
         # The following arguments are optional and can be omitted if not needed.
 
-        # Run EPV (Extension Pre Validator) on your code? 1 or 0
+        # Run phpBB's EPV (Extension Pre Validator)? 1 (yes) or 0 (no)
         # Default: 1
         EPV: 1
 
-        # Run check for executable files? 1 or 0
+        # Check for files with executable permissions? 1 (yes) or 0 (no)
         # Default: 1
         EXECUTABLE_FILES: 1
 
-        # Run icc profile sniffer on your images? 1 or 0
+        # Remove embedded ICC profiles from images? 1 (yes) or 0 (no)
         # Default: 1
         IMAGE_ICC: 1
 
-        # Run code sniffer on your code? 1 or 0
+        # Run CodeSniffer to detect PHP code style issues? 1 (yes) or 0 (no)
         # Default: 1
         SNIFF: 1
 
-        # ADVANCED CONFIGURATIONS BELOW
-        # The following arguments are for users that need to tweak the workflow.
-
-        # Set this to 0 to skip all MySQL/MariaDB tests.
+        # Run MySQL/MariaDB tests? 1 (yes) or 0 (no)
         # Default: 1
         RUN_MYSQL_JOBS: 1
 
-        # Set this to 0 to skip all PostgreSQL tests.
+        # Run PostgreSQL tests? 1 (yes) or 0 (no)
         # Default: 1
         RUN_PGSQL_JOBS: 1
 
-        # Set this to 0 to skip all MSSQL and SQLite3 tests.
+        # Run MSSQL and SQLite3 tests? 1 (yes) or 0 (no)
         # Default: 1
         RUN_MSSQL_JOBS: 1
 
-        # Set this to 0 to skip all Windows IIS & PostgreSQL tests.
+        # Run Windows IIS & PostgreSQL tests? 1 (yes) or 0 (no)
         # Default: 1
         RUN_WINDOWS_JOBS: 1
 
-        # Set this to 1 if your extension relies on NPM dependencies.
+        # Install NPM dependencies (if your extension relies on them)? 1 (yes) or 0 (no)
         # Default: 0
         RUN_NPM_INSTALL: 0
 
-        # Set this to 1 if your extension relies on Composer dependencies.
+        # Install Composer dependencies (if your extension relies on them)? 1 (yes) or 0 (no)
         # Default: 0
         RUN_COMPOSER_INSTALL: 0
 
@@ -137,7 +141,7 @@ call-tests:
         # Default: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
         PHP_VERSION_MATRIX: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
 
-        # Set this to 1 to generate a code coverage report. (See documentation below.)
+        # Generate a code coverage report (see documentation below)? 1 (yes) or 0 (no)
         # Default: 0
         CODECOV: 0
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ on:
 
 jobs:
     call-tests:
+        name: Extension tests
         uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x  # Must match PHPBB_BRANCH
         with:
             EXTNAME: acme/demo   # Your extension vendor/package name
@@ -77,6 +78,7 @@ You can fine-tune this workflow with several optional arguments in the `with` se
 
 ```yaml
 call-tests:
+    name: Extension tests
     uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x
     with:
         EXTNAME: acme/demo   # Your extension vendor/package name


### PR DESCRIPTION
Add more optional variables for users to control the full suite of PHP versions that get tested. Also optional variables to run NPM install and Composer install in an extension's root directory if it uses them for dependencies.