### PR TITLE
Make PHPBB_BRANCH optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,8 @@ on:
         required: true
         type: string
       PHPBB_BRANCH:
-        required: true
+        required: false
+        default: '3.3.x'
         type: string
       SNIFF:
         required: false

--- a/README.md
+++ b/README.md
@@ -46,27 +46,24 @@ on:
 jobs:
     call-tests:
         name: Extension tests
-        uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x  # Must match PHPBB_BRANCH
+        uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x # The phpBB branch to run tests with
         with:
             EXTNAME: acme/demo   # Your extension vendor/package name
-            PHPBB_BRANCH: 3.3.x  # The phpBB branch to run tests on
         secrets:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} # Do not edit or remove this
 ```
 
 ### Branches
 
-Use the branch that matches the phpBB version you're developing for.
+Use the test-framework branch that matches the phpBB version you're developing for:
 
 - `3.3.x`: Targets the phpBB 3.3.x release line.
 - `master`: Targets the latest development version of phpBB (`master` branch).
 
-> ‼️ Whichever branch you choose here, be sure to use the **same value** for both the `PHPBB_BRANCH` and in the `uses:` line after the `@` symbol. For example, if you're targeting the `3.3.x` branch:
+> ‼️ Whichever branch of this framework you choose, be sure it is appended to the `uses:` line after the `@` symbol. For example, if you're targeting the `3.3.x` branch:
 > 
 > ```yaml
 > uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x
-> with:
->     PHPBB_BRANCH: 3.3.x
 > ```
 
 ### Requirements
@@ -84,10 +81,16 @@ call-tests:
     uses: phpbb-extensions/test-framework/.github/workflows/tests.yml@3.3.x
     with:
         EXTNAME: acme/demo   # Your extension vendor/package name
-        PHPBB_BRANCH: 3.3.x  # The phpBB branch to run tests on
 
         # OPTIONAL CONFIGURATIONS BELOW
         # The following arguments are optional and can be omitted if not needed.
+
+        # The phpBB branch to use when running tests.
+        # Default is '3.3.x', which this framework is designed for.
+        # If using a different branch, ensure it's compatible with 3.3.x.
+        # To test with phpBB's master branch, refer to the Branches section of this README.
+        # Default: '3.3.x'
+        PHPBB_BRANCH: '3.3.x'
 
         # Run phpBB's EPV (Extension Pre Validator)? 1 (yes) or 0 (no)
         # Default: 1


### PR DESCRIPTION
Since we only have 2 branches here and they should match the PHPBB_BRANCH option, we can just set them by default. That means PHPBB_BRANCH option can be ignored by calling workflows, as users will be choosing the phpBB branch to test when they pick from one of our repo's branches - 3.3.x or master in their calling workflows.